### PR TITLE
Add datum_handle_t and other common base types

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -146,13 +146,6 @@ typedef struct
   int16_t x1; ///< offset=0x06
 } viewport_bounds_t;
 
-/// size=0x0C
-typedef struct {
-  float x; ///< offset=0x00
-  float y; ///< offset=0x04
-  float z; ///< offset=0x08
-} vector3_t;
-
 /// size=0x54
 typedef struct {
   vector3_t         unk_0;                  ///< offset=0x00

--- a/src/types.h
+++ b/src/types.h
@@ -8,6 +8,9 @@
 #define static_assert(cond) _Static_assert(cond, #cond)
 #endif
 #define NULL ((void*)0)
+#define true 1
+#define false 0 
+#define NONE -1
 
 #define cs(t, s)    static_assert(sizeof(t) == s)
 #define co(t, f, o) static_assert(offsetof(t, f) == o)
@@ -36,10 +39,23 @@ typedef uint8_t _BYTE;
 #define __int16 short
 #define __int8 char
 
-static const bool true = 1;
-static const bool false = 0;
-
 #pragma pack(1)
+
+/// size=0x0C
+typedef struct {
+  float x; ///< offset=0x00
+  float y; ///< offset=0x04
+  float z; ///< offset=0x08
+} vector3_t;
+
+/// size=0x04
+typedef union {
+  int32_t value;   ///< offset=0x00
+  struct {
+    int16_t index; ///< offset=0x00
+    int16_t salt;  ///< offset=0x02
+  };
+} datum_handle_t;
 
 /// size=0x10c
 typedef struct {


### PR DESCRIPTION
This PR moves `vector3_t` up a bit in preparation for other structs to be added later. The `datum_handle_t` type is actually referred to as a datum index by Bungie, but it makes more sense to be a handle with value composed of an index and salt instead. Booleans have been converted to defines because constant propagation doesn't appear to happen on Windows builds (under my environment at least). `NONE` is also a common reference used throughout the code-base, not to be confused by the `NONE` flag/enum value which is usually/always? 0 instead of -1.