### PR TITLE
Main: Include stdlib for c qsort method

### DIFF
--- a/src/halo/main/main.c
+++ b/src/halo/main/main.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 short game_connection(void)
 {
   return word_46DA0C;


### PR DESCRIPTION
This commit fixes the missing function for using qsort: https://blam.info/progress/?f=qsort#callgraph